### PR TITLE
Optimize samtools + add bzip2 support

### DIFF
--- a/shared.sh
+++ b/shared.sh
@@ -1,13 +1,29 @@
 # Commonly used emcc compilation variables
 
-EM_FLAGS=$(cat <<EOF
+EM_FLAGS_BASE=$(cat <<EOF
     -s USE_ZLIB=1
     -s INVOKE_RUN=0
-    -s ALLOW_MEMORY_GROWTH=1
     -s FORCE_FILESYSTEM=1
     -s EXTRA_EXPORTED_RUNTIME_METHODS=["callMain"]
     -lworkerfs.js
 EOF
 )
 
+EM_FLAGS=$(cat <<EOF
+    ${EM_FLAGS_BASE}
+    -s ALLOW_MEMORY_GROWTH=1
+EOF
+)
+
+# Note: avoid using memory growth with threads (see https://emscripten.org/docs/porting/pthreads.html)
+EM_FLAGS_THREADS=$(cat <<EOF
+    ${EM_FLAGS_BASE}
+    -s USE_PTHREADS=1
+    -s PTHREAD_POOL_SIZE=10
+    -s TOTAL_MEMORY=100MB
+    --threadprofiler
+EOF
+)
+
 export EM_FLAGS;
+export EM_FLAGS_THREADS;

--- a/tools/htslib/compile.sh
+++ b/tools/htslib/compile.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
-# TODO: figure out "--disable-bz2 --disable-lzma"
+# TODO: look into LZMA support
 
 # Dependencies
 apt-get install -y zlib1g-dev libbz2-dev liblzma-dev libcurl4-gnutls-dev libssl-dev
 
 # Run ./configure
 cd src/
+make clean
 autoheader
 autoconf
-emconfigure ./configure CFLAGS="-s USE_ZLIB=1" --disable-bz2 --disable-lzma
+emconfigure ./configure CFLAGS="-s USE_ZLIB=1 -s USE_BZIP2=1" --disable-lzma

--- a/tools/samtools/compile.sh
+++ b/tools/samtools/compile.sh
@@ -11,15 +11,16 @@ make clean
 # Also, use autoheader/autoconf to generate config.h.in and configure
 autoheader
 autoconf -Wno-syntax
-emconfigure ./configure --without-curses --with-htslib="../../htslib/src/" CFLAGS="-s USE_ZLIB=1"
-emmake make CC=emcc AR=emar
+emconfigure ./configure --without-curses --with-htslib="../../htslib/src/" CFLAGS="-s USE_ZLIB=1 -s USE_BZIP2=1"
+emmake make CC=emcc AR=emar CFLAGS="-O2 -s USE_ZLIB=1 -s USE_BZIP2=1"
 
 # Rename output to .o so it's recognizable by Emscripten
 cp samtools samtools.o
 
-# Generate .wasm/.js files 
-emcc samtools.o \
+# Generate .wasm/.js files
+emcc -O2 samtools.o \
     -o ../build/samtools.html \
     $EM_FLAGS \
+    -s USE_BZIP2=1 \
     -s ERROR_ON_UNDEFINED_SYMBOLS=0 \
     --preload-file examples/@/tmp/examples/

--- a/tools/samtools/compile.sh
+++ b/tools/samtools/compile.sh
@@ -1,38 +1,13 @@
 #!/bin/bash
 
-# TODO: look into:
-#   shared:WARNING: emcc: cannot find library "bz2"
-#   shared:WARNING: emcc: cannot find library "lzma"
-#   warning: undefined symbol: bam_aux_append
-#   warning: undefined symbol: bam_aux_get
-#   warning: undefined symbol: bam_copy1
-#   warning: undefined symbol: bam_endpos
-#   warning: undefined symbol: bam_hdr_destroy
-#   warning: undefined symbol: bam_hdr_init
-#   warning: undefined symbol: bgzf_hopen
-#   warning: undefined symbol: bgzf_read
-#   warning: undefined symbol: cram_get_refs
-#   warning: undefined symbol: hopen_callback
-#   warning: undefined symbol: hts_close
-#   warning: undefined symbol: hts_idx_destroy
-#   warning: undefined symbol: hts_itr_destroy
-#   warning: undefined symbol: hts_itr_next
-#   warning: undefined symbol: hts_open
-#   warning: undefined symbol: hts_open_callback
-#   warning: undefined symbol: hts_set_fai_filename
-#   warning: undefined symbol: hts_set_opt
-#   warning: undefined symbol: sam_hdr_read
-#   warning: undefined symbol: sam_hdr_write
-#   warning: undefined symbol: sam_index_load
-#   warning: undefined symbol: sam_itr_queryi
-#   warning: undefined symbol: sam_read1
-#   warning: undefined symbol: sam_write1
+# TODO: look into LZMA support
 
 test -d ../htslib/build/ || echo "Run 'make htslib' first."
 
 cd src/
 
-# Patch: Reset "opt" variables so that it works properly when call main() multiple times
+make clean
+
 # Also, use autoheader/autoconf to generate config.h.in and configure
 autoheader
 autoconf -Wno-syntax


### PR DESCRIPTION
A few updates to htslib & samtools:

* Forgot to do `-O2` during the final `emcc` compilation step, so I'm adding it here. This reduces `.wasm` file size from 2.1MB to 962KB and `.js` from 311KB to 124KB.
* Add `bzip2` support during compilation
